### PR TITLE
Fix permissions for tor data mounts

### DIFF
--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -3,6 +3,9 @@ set -o errexit
 
 echo -e "\\n========================================================"
 
+# If DataDirectory or secret_id_key is mounted here, it must be owned by the debian-tor user
+chown -Rv debian-tor:debian-tor /var/lib/tor
+
 if [ ! -e /tor-config-done ]; then
     touch /tor-config-done   # only run this once
 


### PR DESCRIPTION
This line was deleted after the fork which I think will fix my permission issues in the `/var/lib/tor` directory.