### PR TITLE
Add unattended upgrades and automatic reboot configuration for Tor relay Docker image

### DIFF
--- a/20auto-upgrades
+++ b/20auto-upgrades
@@ -1,0 +1,5 @@
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::AutocleanInterval "5";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Verbose "1";
+Unattended-Upgrade::Automatic-Reboot "true";

--- a/50unattended-upgrades
+++ b/50unattended-upgrades
@@ -1,0 +1,6 @@
+Unattended-Upgrade::Origins-Pattern {
+    "origin=Debian,codename=${distro_codename},label=Debian-Security";
+    "origin=TorProject";
+};
+Unattended-Upgrade::Package-Blacklist {
+};

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,3 @@
-#
-# Dockerfile for Tor Relay Server
-#
-# This will build & install a Tor Debian package using
-# the official instructions for installing Tor on Debian Jessie from source
-# as detailed here https://www.torproject.org/docs/debian.html.en
-#
-# Usage:
-#   docker run -d --restart=always -p 9001:9001 doudou34/tor-server
-
 FROM debian:bullseye
 LABEL MAINTAINER="Edouard COMTET<edouard.comtet@gmail.com>"
 
@@ -16,18 +6,25 @@ ENV TOR_NICKNAME=Tor4
 ENV TERM=xterm
 
 RUN apt-get update \
-    && apt-get install -y apt-transport-https wget gpg
-RUN apt-get install unattended-upgrades apt-listchanges
-# Copy docker-entrypoint
-COPY ./scripts/ /usr/local/bin/
-COPY tor.sources.list /etc/apt/sources.list.d/tor.list
+    && apt-get install -y apt-transport-https wget gpg \
+    && apt-get install -y unattended-upgrades apt-listchanges
 
-RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
-RUN apt-get update \
-    && apt-get install -y tor deb.torproject.org-keyring \
-    && apt-get install -y pwgen \
+RUN apt-get install -y pwgen \
     && apt-get -y purge --auto-remove \
     && apt-get clean
+
+# Ajouter le fichier de configuration pour les mises à jour automatiques
+COPY tor.sources.list /etc/apt/sources.list.d/tor.list
+COPY 50unattended-upgrades /etc/apt/apt.conf.d/50unattended-upgrades
+COPY 20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Copier docker-entrypoint
+COPY ./scripts/ /usr/local/bin/
+
+# Importer la clé GPG du dépôt Tor
+RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
+RUN apt-get update \
+    && apt-get install -y tor deb.torproject.org-keyring
 
 # Persist data
 VOLUME /etc/tor /var/lib/tor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+#
+# Dockerfile for Tor Relay Server
+#
+# This will build & install a Tor Debian package using
+# the official instructions for installing Tor on Debian Jessie from source
+# as detailed here https://www.torproject.org/docs/debian.html.en
+#
+# Usage:
+#   docker run -d --restart=always -p 9001:9001 doudou34/tor-server
+
 FROM debian:bullseye
 LABEL MAINTAINER="Edouard COMTET<edouard.comtet@gmail.com>"
 
@@ -9,22 +19,18 @@ RUN apt-get update \
     && apt-get install -y apt-transport-https wget gpg \
     && apt-get install -y unattended-upgrades apt-listchanges
 
-RUN apt-get install -y pwgen \
-    && apt-get -y purge --auto-remove \
-    && apt-get clean
-
-# Ajouter le fichier de configuration pour les mises à jour automatiques
+# Copy docker-entrypoint
+COPY ./scripts/ /usr/local/bin/
 COPY tor.sources.list /etc/apt/sources.list.d/tor.list
 COPY 50unattended-upgrades /etc/apt/apt.conf.d/50unattended-upgrades
 COPY 20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
 
-# Copier docker-entrypoint
-COPY ./scripts/ /usr/local/bin/
-
-# Importer la clé GPG du dépôt Tor
 RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
 RUN apt-get update \
-    && apt-get install -y tor deb.torproject.org-keyring
+    && apt-get install -y tor deb.torproject.org-keyring \
+    && apt-get install -y pwgen \
+    && apt-get -y purge --auto-remove \
+    && apt-get clean
 
 # Persist data
 VOLUME /etc/tor /var/lib/tor

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV TERM=xterm
 
 RUN apt-get update \
     && apt-get install -y apt-transport-https wget gpg
-
+RUN apt-get install unattended-upgrades apt-listchanges
 # Copy docker-entrypoint
 COPY ./scripts/ /usr/local/bin/
 COPY tor.sources.list /etc/apt/sources.list.d/tor.list


### PR DESCRIPTION
This pull request aims to improve the Tor relay Docker image by adding unattended upgrades and automatic reboot configuration. By doing so, the image will benefit from better security and maintenance, as it will automatically apply updates and restart when necessary.

**The changes include:**

1. Installing the required packages for unattended upgrades: unattended-upgrades and apt-listchanges.

2. Adding the configuration file 50unattended-upgrades to define the update origins and package blacklist. This file is specific to Debian and allows updates from the TorProject repository.

3. Adding the configuration file 20auto-upgrades to set the update frequency, enable unattended upgrades, and enable automatic reboots when necessary.

4. Updating the Dockerfile to include these new configuration files and install the required packages.

With these changes, the Tor relay Docker image will be more secure and easier to maintain, as it will automatically apply updates and restart when necessary. This will ensure that the relay is always running the latest version of Tor and associated packages, improving its overall security and stability.